### PR TITLE
add context information to DLN emails

### DIFF
--- a/src/main/java/uk/ac/ebi/subs/dlqemailer/config/EmailMustacheProperties.java
+++ b/src/main/java/uk/ac/ebi/subs/dlqemailer/config/EmailMustacheProperties.java
@@ -14,4 +14,8 @@ public class EmailMustacheProperties {
 
     private String numberOfMessages;
     private Set<Map.Entry<String,Long>> countByRoutingKey;
+    private String configName;
+    private String hostname;
+    private String username;
+    private Long messageRate;
 }

--- a/src/main/java/uk/ac/ebi/subs/dlqemailer/config/EnvironmentProperties.java
+++ b/src/main/java/uk/ac/ebi/subs/dlqemailer/config/EnvironmentProperties.java
@@ -1,0 +1,14 @@
+package uk.ac.ebi.subs.dlqemailer.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "usi.environment")
+public class EnvironmentProperties {
+
+    private String name;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,7 @@ dlqEmailer:
     to: to@example.com
     replyTo: reply-to@example.com
     notificationScheduling: 30000
+
+usi:
+  environment:
+    name: notset

--- a/src/main/resources/dead_letter_notifier_email_template.mustache
+++ b/src/main/resources/dead_letter_notifier_email_template.mustache
@@ -10,8 +10,12 @@ Message count by routing key:
 
 You can find the first message by routing key in the attachment.
 
-Happy fixing! :-)
-
+Thanks,
 Dead Letter Notifier
+
+Sent from {{hostname}} by {{username}}, using the {{configName}} config
+Messages sent every {{messageRate}} milliseconds
+
+
 
 


### PR DESCRIPTION
E-mails now have this sort of body:

Dear Subs Team,

In the last period the dead letter exchange received 10 messages(s).

Message count by routing key:

routingKey1: 3
routingKey2: 3
routingKey3: 4

You can find the first message by routing key in the attachment.

Thanks,
Dead Letter Notifier

Sent from davidr-ml by davidr, using the notset config
Messages sent every 30000 milliseconds




